### PR TITLE
service server for unlocking the protective stop

### DIFF
--- a/include/ur_modern_driver/ur_driver.h
+++ b/include/ur_modern_driver/ur_driver.h
@@ -52,6 +52,7 @@ private:
 	double firmware_version_;
 	double servoj_lookahead_time_;
 	double servoj_gain_;
+	std::string host_;
 public:
 	UrRealtimeCommunication* rt_interface_;
 	UrCommunication* sec_interface_;
@@ -96,6 +97,7 @@ public:
 	void setServojLookahead(double t);
 	void setServojGain(double g);
 
+	bool unlockProtectiveStop();
 };
 
 #endif /* UR_DRIVER_H_ */


### PR DESCRIPTION
The universal dashboard (port 29999) is used to unlock the protective
stop.

This also adds a distinction in the trajectory abort error string whether
the abort is due to a protective stop or an emergency stop.